### PR TITLE
Introduct docker compose config for wallabag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wallabag/data/

--- a/wallabag/docker-compose.yml
+++ b/wallabag/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  wallabag:
+    image: wallabag/wallabag
+    restart: unless-stopped
+    environment:
+      - SYMFONY__ENV__DATABASE_DRIVER=pdo_sqlite
+      - SYMFONY__ENV__DATABASE__PATH=/var/www/wallabag/data/db/wallabag.sqlite
+      - SYMFONY__ENV__DATABASE_NAME=wallabag
+      - SYMFONY__ENV__DATABASE_USER=wallabag
+      - SYMFONY__ENV__DATABASE_PASSWORD=wallapass
+      - SYMFONY__ENV__DATABASE_TABLE_PREFIX="wallabag_"
+      - SYMFONY__ENV__MAILER_DSN=smtp://127.0.0.1
+      - SYMFONY__ENV__FROM_EMAIL=me@kingscott.ca
+      - SYMFONY__ENV__DOMAIN_NAME=http://localhost
+      - SYMFONY__ENV__SERVER_NAME="Scott's Wallabag"
+    ports:
+      - "8080:80"
+    volumes:
+      - ./data:/var/www/wallabag/data
+    depends_on:
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+  redis:
+    image: redis:alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 20s
+      timeout: 3s


### PR DESCRIPTION
## Summary

Add support for wallabag on homelab. This is default, out of the box. No SSL cert (or config for one) exists yet, so it's the application with configuration for storage.

Added health check for when glance is up and running.