### PR TITLE
Add docker compose support for running nginx proxy manager and cloudflare ddns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
+# Wallabag
 wallabag/data/
+
+# nginx proxy manager
+proxy/data
+proxy/letsencrypt
+
+

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  proxy:
+    image: 'jc21/nginx-proxy-manager:latest'
+    container_name: nginx-proxy-manager
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./data:/data
+      - ./letsencrypt:/etc/letsencrypt
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:81"]
+      interval: 10s
+      timeout: 3s
+      retries: 3

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -12,3 +12,17 @@ services:
       interval: 10s
       timeout: 3s
       retries: 3
+  ddns:
+    image: favonia/cloudflare-ddns:latest
+    container_name: cloudflare-ddns
+    # network_mode: host # This bypasses network isolation and makes IPv6 easier (optional; see below)
+    restart: unless-stopped
+    user: "1000:1000" # Run the updater with specific user and group IDs (in that order).
+    read_only: true # Make the container filesystem read-only (optional but recommended)
+    cap_drop: [all] # Drop all Linux capabilities (optional but recommended)
+    security_opt: [no-new-privileges:true] # Another protection to restrict superuser privileges (optional but recommended)
+    environment:
+      - CLOUDFLARE_API_TOKEN=KEY
+      - DOMAINS=example.com,jellyfin.example.com
+      - PROXIED=true
+      - IP6_PROVIDER=none


### PR DESCRIPTION
## Summary

Add ability to run nginx-proxy-manager locally on homelab. Leverages default network settings on host, using ports 80, 81, 443. 

Also runs the Cloudflare DDNS base config for dynamic IP resolution.