### PR TITLE
feat: Add setup files for self-hosted recipe organizer: Mealie

### DIFF
--- a/mealie/.env.example
+++ b/mealie/.env.example
@@ -1,0 +1,14 @@
+# Mealie Environment Configuration
+# Copy this file to .env and update with your actual values
+
+# Permissions
+ALLOW_SIGNUP="false"
+PUID=1000
+PGID=1000
+
+# metadata
+TZ=America/Toronto
+
+# Domain to publish mealie
+BASE_URL=https://mealie.yourdomain.com
+

--- a/mealie/docker-compose.yml
+++ b/mealie/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  mealie:
+    image: ghcr.io/mealie-recipes/mealie:v3.5.0
+    container_name: mealie
+    restart: always
+    ports:
+        - "9925:9000"
+    deploy:
+      resources:
+        limits:
+          memory: 1000M
+    volumes:
+      - mealie-data:/app/data/
+    environment:
+      ALLOW_SIGNUP: ${ALLOW_SIGNUP}
+      PUID: ${PUID}
+      PGID: ${PGID}
+      TZ: ${TZ}
+      BASE_URL: ${BASE_URL}
+
+volumes:
+  mealie-data:


### PR DESCRIPTION
- Add env.example file
- Add docker-compose file to easily scaffold service 