### PR TITLE
Configure miniflux to poll feeds once daily

### DIFF
--- a/miniflux/.env.example
+++ b/miniflux/.env.example
@@ -4,3 +4,5 @@ POSTGRES_PASSWORD=changeme
 POSTGRES_DB=miniflux
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=changeme
+# How often to poll feeds, in minutes. 1440 = once per day.
+POLLING_FREQUENCY=1440

--- a/miniflux/docker-compose.yml
+++ b/miniflux/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       CREATE_ADMIN: 1
       ADMIN_USERNAME: ${ADMIN_USERNAME}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+      POLLING_FREQUENCY: ${POLLING_FREQUENCY:-1440}
   db:
     image: postgres:18
     container_name: miniflux-db


### PR DESCRIPTION
## Summary

Adds configuration for miniflux feed polling frequency to reduce noise from high-volume feeds like HackerNews and Reddit.

- Sets `POLLING_FREQUENCY=1440` (24 hours) instead of the default 60 minutes
- Configurable via environment variable (defaults to 1440 in .env.example)
- Per-feed entry limits must be configured individually in the UI

## Manual Steps

After deployment, configure individual feeds:
1. Navigate to **Feeds** → select feed → **Edit**
2. Set **"Maximum number of entries to keep"** to desired limit (e.g., 10)
3. Save

This per-feed limit cannot be set globally via environment variables in miniflux.

## Testing

After deploying with `docker compose up -d`:
```bash
docker exec miniflux miniflux -config-dump | grep -i polling
```

Or verify in the miniflux UI: **Settings** → **About** shows next scheduled refresh time.